### PR TITLE
Pinned lib_i2c to >=6.2.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Board Support Library Changelog
 ===============================
 
+0.1.1
+-----
+
+  * CHANGED: Pinned lib_i2c to >=6.2.0
+
 0.1.0
 -----
 

--- a/lib_board_support/lib_build_info.cmake
+++ b/lib_board_support/lib_build_info.cmake
@@ -2,6 +2,6 @@ set(LIB_NAME lib_board_support)
 set(LIB_VERSION 0.1.0)
 set(LIB_INCLUDES api/boards api/drivers)
 set(LIB_COMPILER_FLAGS -O3 -g)
-set(LIB_DEPENDENT_MODULES "lib_i2c(>=6.2.0)")
+set(LIB_DEPENDENT_MODULES "lib_i2c(6.2.0)")
 
 XMOS_REGISTER_MODULE()

--- a/lib_board_support/lib_build_info.cmake
+++ b/lib_board_support/lib_build_info.cmake
@@ -2,6 +2,6 @@ set(LIB_NAME lib_board_support)
 set(LIB_VERSION 0.1.0)
 set(LIB_INCLUDES api/boards api/drivers)
 set(LIB_COMPILER_FLAGS -O3 -g)
-set(LIB_DEPENDENT_MODULES "lib_i2c")
+set(LIB_DEPENDENT_MODULES "lib_i2c(>=6.2.0)")
 
 XMOS_REGISTER_MODULE()

--- a/lib_board_support/module_build_info
+++ b/lib_board_support/module_build_info
@@ -1,6 +1,6 @@
 VERSION = 0.1.0
 
-DEPENDENT_MODULES = lib_i2c
+DEPENDENT_MODULES = lib_i2c(>=6.2.0)
 
 MODULE_XCC_FLAGS = $(XCC_FLAGS) \
                    -O3 -g


### PR DESCRIPTION
tested here http://srv-bri-jcim0:8080/blue/organizations/jenkins/XMOS%2Fsw_usb_audio/detail/PR-251/29/pipeline 