### PR TITLE
Sync link state with mac

### DIFF
--- a/lib_board_support/src/boards/xk_eth_xu316_dual_100m/xk_eth_xu316_dual_100m.xc
+++ b/lib_board_support/src/boards/xk_eth_xu316_dual_100m/xk_eth_xu316_dual_100m.xc
@@ -131,7 +131,7 @@ void dual_dp83826e_phy_driver(CLIENT_INTERFACE(smi_if, i_smi),
         // "Here this is a mistake in the datasheet, but please test which led has what registers, to my knowledge the settings described will configure the Leds mentioned."
         // "Led LED grouping is swapped so LED1 is 3-0 LED2 is 7-4 and LED3 is 11-8 the description status the same. Please confirm with your tests"
         smi_mmd_write(i_smi, phy_address, 0x001F, 0x0460, 0x0555);
-        
+
         // Set pins to higher drive strength "impedance control". This is needed especially for clock signal. This results in a wider eye by some 2ns also.
         // Note we also ensure RXDV is set too
         smi_mmd_write(i_smi, phy_address, 0x001F, 0x0302, 0xC100);
@@ -164,7 +164,16 @@ void dual_dp83826e_phy_driver(CLIENT_INTERFACE(smi_if, i_smi),
                     int phy_address = phy_addresses[phy_idx];
                     ethernet_link_state_t new_state = smi_get_link_state(i_smi, phy_address);
 
-                    if (new_state != link_state[phy_idx]) {
+                    // Get the current link state that the mac is aware of. In case the mac has restarted and lost all state...
+                    unsigned link_state_known_to_mac, link_speed_known_to_mac;
+                    if(phy_idx == 0)
+                    {
+                        i_eth_phy0.get_link_state(0, link_state_known_to_mac, link_speed_known_to_mac);
+                    } else {
+                        i_eth_phy1.get_link_state(0, link_state_known_to_mac, link_speed_known_to_mac);
+                    }
+
+                    if ((new_state != link_state[phy_idx]) || (new_state != link_state_known_to_mac)) {
                         link_state[phy_idx] = new_state;
                         if(phy_idx == 0){
                             i_eth_phy0.set_link_state(0, new_state, link_speed[phy_idx]);

--- a/lib_board_support/src/boards/xk_eth_xu316_dual_100m/xk_eth_xu316_dual_100m.xc
+++ b/lib_board_support/src/boards/xk_eth_xu316_dual_100m/xk_eth_xu316_dual_100m.xc
@@ -164,16 +164,7 @@ void dual_dp83826e_phy_driver(CLIENT_INTERFACE(smi_if, i_smi),
                     int phy_address = phy_addresses[phy_idx];
                     ethernet_link_state_t new_state = smi_get_link_state(i_smi, phy_address);
 
-                    // Get the current link state that the mac is aware of. In case the mac has restarted and lost all state...
-                    unsigned link_state_known_to_mac, link_speed_known_to_mac;
-                    if(phy_idx == 0)
-                    {
-                        i_eth_phy0.get_link_state(0, link_state_known_to_mac, link_speed_known_to_mac);
-                    } else {
-                        i_eth_phy1.get_link_state(0, link_state_known_to_mac, link_speed_known_to_mac);
-                    }
-
-                    if ((new_state != link_state[phy_idx]) || (new_state != link_state_known_to_mac)) {
+                    if (new_state != link_state[phy_idx]) {
                         link_state[phy_idx] = new_state;
                         if(phy_idx == 0){
                             i_eth_phy0.set_link_state(0, new_state, link_speed[phy_idx]);
@@ -201,6 +192,11 @@ void dual_dp83826e_phy_driver(CLIENT_INTERFACE(smi_if, i_smi),
                 }
                 t += link_poll_period_ms * XS1_TIMER_KHZ;
             break;
+            case i_eth_phy0.mac_started():
+                // Mac has just started, or restarted
+                i_eth_phy0.set_link_state(0, link_state[0], link_speed[0]);
+                break;
+
         }
     }
 }

--- a/lib_board_support/src/boards/xk_eth_xu316_dual_100m/xk_eth_xu316_dual_100m.xc
+++ b/lib_board_support/src/boards/xk_eth_xu316_dual_100m/xk_eth_xu316_dual_100m.xc
@@ -192,7 +192,7 @@ void dual_dp83826e_phy_driver(CLIENT_INTERFACE(smi_if, i_smi),
                 }
                 t += link_poll_period_ms * XS1_TIMER_KHZ;
             break;
-
+#if ENABLE_MAC_START_NOTIFICATION
             case use_phy0 => i_eth_phy0.mac_started():
                 // Mac has just started, or restarted
                 i_eth_phy0.set_link_state(0, link_state[0], link_speed[0]);
@@ -202,7 +202,7 @@ void dual_dp83826e_phy_driver(CLIENT_INTERFACE(smi_if, i_smi),
                 // Mac has just started, or restarted
                 i_eth_phy1.set_link_state(0, link_state[1], link_speed[1]);
             break;
-
+#endif
         }
     }
 }

--- a/lib_board_support/src/boards/xk_eth_xu316_dual_100m/xk_eth_xu316_dual_100m.xc
+++ b/lib_board_support/src/boards/xk_eth_xu316_dual_100m/xk_eth_xu316_dual_100m.xc
@@ -192,10 +192,16 @@ void dual_dp83826e_phy_driver(CLIENT_INTERFACE(smi_if, i_smi),
                 }
                 t += link_poll_period_ms * XS1_TIMER_KHZ;
             break;
-            case i_eth_phy0.mac_started():
+
+            case use_phy0 => i_eth_phy0.mac_started():
                 // Mac has just started, or restarted
                 i_eth_phy0.set_link_state(0, link_state[0], link_speed[0]);
-                break;
+            break;
+
+            case use_phy1 => i_eth_phy1.mac_started():
+                // Mac has just started, or restarted
+                i_eth_phy1.set_link_state(0, link_state[1], link_speed[1]);
+            break;
 
         }
     }

--- a/lib_board_support/src/boards/xk_eth_xu316_dual_100m/xk_eth_xu316_dual_100m.xc
+++ b/lib_board_support/src/boards/xk_eth_xu316_dual_100m/xk_eth_xu316_dual_100m.xc
@@ -195,11 +195,13 @@ void dual_dp83826e_phy_driver(CLIENT_INTERFACE(smi_if, i_smi),
 #if ENABLE_MAC_START_NOTIFICATION
             case use_phy0 => i_eth_phy0.mac_started():
                 // Mac has just started, or restarted
+                i_eth_phy0.ack_mac_start();
                 i_eth_phy0.set_link_state(0, link_state[0], link_speed[0]);
             break;
 
             case use_phy1 => i_eth_phy1.mac_started():
                 // Mac has just started, or restarted
+                i_eth_phy1.ack_mac_start();
                 i_eth_phy1.set_link_state(0, link_state[1], link_speed[1]);
             break;
 #endif


### PR DESCRIPTION
When receiving a mac_started notification from the ethernet_server, respond with the current link state.

This is required for the mac to receive the current link state after it receives an exit and restarts.

https://github.com/xmos/lib_ethernet/tree/experimental/hw_test has code for testing this. It extends the ethernet_cfg_if to  add a mac_started() notification and a corresponding ack_mac_start() to clear the notification.

Once this is merged, [examples/deps.cmake](https://github.com/xmos/lib_ethernet/blob/experimental/hw_test/examples/deps.cmake) can go back to lib_board_support(develop)