### PR TITLE
Enum for get_port_timings(),  single and dual PHY operation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ UNRELEASED
   * ADDED: Support for PHY address being either 0x1 or 0x4 for XK-EVK-XE216
   * ADDED: Power-down support for xk-audio-316-mc
   * ADDED: xcore core voltage control API for xk-audio-316-mc
+  * CHANGED: replaced phy_idx paramter in get_port_timings() with enum, port_timing_index_t
 
 1.2.2
 -----

--- a/lib_board_support/api/boards/xk_eth_xu316_dual_100m/board.h
+++ b/lib_board_support/api/boards/xk_eth_xu316_dual_100m/board.h
@@ -31,7 +31,7 @@
 typedef enum {
     DUAL_PHY_MOUNTED_PHY0,
     DUAL_PHY_MOUNTED_PHY1,
-    SINGLE_PHY_MOUNTED,
+    SINGLE_PHY_MOUNTED_PHY0,
 } port_timing_index_t;
 
 /** Task that connects to the SMI master and MAC to configure the
@@ -63,7 +63,7 @@ void reset_eth_phys(void);
  * ensure setup and hold times are maximised at the pin level of the PHY connection.
  * rmii_port_timing_t is defined in lib_ethernet.
  * 
- *  \param phy_idx      The index of the PHY to get timing data about (0 or 1).
+ *  \param phy_idx      The index of the PHY to get timing data about.
  *  \returns            The timing struct to be passed to the PHY.
  */
 rmii_port_timing_t get_port_timings(port_timing_index_t phy_idx);

--- a/lib_board_support/api/boards/xk_eth_xu316_dual_100m/board.h
+++ b/lib_board_support/api/boards/xk_eth_xu316_dual_100m/board.h
@@ -23,6 +23,17 @@
  * @{
  */
 
+ /** Index value used with get_port_timings() to refer to board configuration.
+  * 
+  * The timings change according to which PHYs mounted and the hardware configuration
+  * of the dual PHY dev-kit.
+  */
+typedef enum {
+    DUAL_PHY_MOUNTED_PHY0,
+    DUAL_PHY_MOUNTED_PHY1,
+    SINGLE_PHY_MOUNTED,
+} port_timing_index_t;
+
 /** Task that connects to the SMI master and MAC to configure the
  * DP83826E PHYs and monitor the link status. Note this task is combinable
  * (typically with SMI) and therefore does not need to take a whole thread.
@@ -55,7 +66,7 @@ void reset_eth_phys(void);
  *  \param phy_idx      The index of the PHY to get timing data about (0 or 1).
  *  \returns            The timing struct to be passed to the PHY.
  */
-rmii_port_timing_t get_port_timings(int phy_idx);
+rmii_port_timing_t get_port_timings(port_timing_index_t phy_idx);
 
 
 /**@}*/ // END: addtogroup xk_eth_xu316_dual_100m

--- a/lib_board_support/src/boards/xk_eth_xu316_dual_100m/xk_eth_xu316_dual_100m.xc
+++ b/lib_board_support/src/boards/xk_eth_xu316_dual_100m/xk_eth_xu316_dual_100m.xc
@@ -44,15 +44,15 @@ void reset_eth_phys()
     delay_milliseconds(2);
 }
 
-rmii_port_timing_t get_port_timings(int phy_idx){
+rmii_port_timing_t get_port_timings(port_timing_index_t phy_idx){
     rmii_port_timing_t port_timing = {0};
-    if(phy_idx == 0){
+    if(phy_idx == DUAL_PHY_MOUNTED_PHY0){
         port_timing.clk_delay_tx_rising = 1;
         port_timing.clk_delay_tx_falling = 1;
         port_timing.clk_delay_rx_rising = 0;
         port_timing.clk_delay_tx_rising = 0;
         port_timing.pad_delay_rx = 1;
-    } else if(phy_idx == 1) {
+    } else if((phy_idx == DUAL_PHY_MOUNTED_PHY1) || (phy_idx == SINGLE_PHY_MOUNTED)) {
         port_timing.clk_delay_tx_rising = 0;
         port_timing.clk_delay_tx_falling = 0;
         port_timing.clk_delay_rx_rising = 0;

--- a/lib_board_support/src/boards/xk_eth_xu316_dual_100m/xk_eth_xu316_dual_100m.xc
+++ b/lib_board_support/src/boards/xk_eth_xu316_dual_100m/xk_eth_xu316_dual_100m.xc
@@ -52,7 +52,7 @@ rmii_port_timing_t get_port_timings(port_timing_index_t phy_idx){
         port_timing.clk_delay_rx_rising = 0;
         port_timing.clk_delay_tx_rising = 0;
         port_timing.pad_delay_rx = 1;
-    } else if((phy_idx == DUAL_PHY_MOUNTED_PHY1) || (phy_idx == SINGLE_PHY_MOUNTED)) {
+    } else if((phy_idx == DUAL_PHY_MOUNTED_PHY1) || (phy_idx == SINGLE_PHY_MOUNTED_PHY0)) {
         port_timing.clk_delay_tx_rising = 0;
         port_timing.clk_delay_tx_falling = 0;
         port_timing.clk_delay_rx_rising = 0;


### PR DESCRIPTION
Adding enum for get_port_timings() to clearly indicate the difference between single and dual PHY operation