### PR TITLE
Check for definition of interface before declaring it

### DIFF
--- a/lib_board_support/api/boards/xk_eth_xu316_dual_100m/board.h
+++ b/lib_board_support/api/boards/xk_eth_xu316_dual_100m/board.h
@@ -9,11 +9,13 @@
 #include <xccompat.h>
 #include "smi.h"
 
+#ifndef NULLABLE_CLIENT_INTERFACE
 #ifdef __XC__
 #define NULLABLE_CLIENT_INTERFACE(tag, name) client interface tag ?name
 #else
 #define NULLABLE_CLIENT_INTERFACE(type, name) unsigned name
 #endif
+#endif // NULLABLE_CLIENT_INTERFACE
 
 
 /**


### PR DESCRIPTION
Useful defintiion NULLABLE_CLIENT_INTERFACE in board.h, nice extension to xccompat.h

But, not ideal for including in api header files. As this means board.h must be included in every project source file that has decomentation generated from it. Or, create a duplicate macro with different name (not ideal).

Adding definition check before defining, means it can co-exist with project local compat files (xccompat2.h in case of lib_xtcp).