### PR TITLE
Adding dual ethernet 316 dev-kit

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,12 +1,16 @@
 lib_board_support change log
 ============================
 
-UNRELEASED
-----------
+1.4.0
+-----
 
-  * FIXED:     Incorrect link-speed reported for XK-EVK-XE216 v1.3
   * ADDED:     Support for optional configuration header file
     `board_support_conf.h`
+  * ADDED:     Support for xcore.ai Ethernet development kit `XK-ETH-316-DUAL`.
+    Single PHY support only at this time (ETH0).
+  * ADDED:     Debug units for `XK-ETH-316-DUAL`. `XK-ETH-XU316-DUAL-100M` and
+    `XK-EVK-XE216`.
+  * FIXED:     Incorrect link-speed reported for XK-EVK-XE216 v1.3
 
   * Changes to dependencies:
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
         )
         string(
             name: 'XMOSDOC_VERSION',
-            defaultValue: 'v7.3.0',
+            defaultValue: 'v7.4.0',
             description: 'The xmosdoc version'
         )
         string(

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ lib_board_support: XMOS board support
 #####################################
 
 :vendor: XMOS
-:version: 1.3.0
+:version: 1.4.0
 :scope: General Use
 :description: Support library for XMOS development kits
 :category: General Purpose
@@ -29,7 +29,7 @@ Features
   * ``XK_AUDIO_316_MC``
   * ``XK_AUDIO_216_MC``
   * ``XK_EVK_XU216``
-  * ``XK_ETH_XU316_DUAL_100M``
+  * ``XK_ETH_316_DUAL``
 
 * Simple examples demonstrating usage from both `XC` and `C`.
 
@@ -37,16 +37,9 @@ Features
 Known issues
 ************
 
-* XK_EVK_XU216 support is currently only for the GigE PHY. The required dependency lib_ethernet to support
-  SMI has not been added to this repo to avoid unneeded dependencies in non-Ethernet applications and will
-  be required by any Ethernet application for this board anyway.
-
-* XK_ETH_XU316_DUAL_100M is currently an unreleased board and hence has no documentation.
-
-* XK_ETH_XU316_DUAL_100M uses the TI DP83826 PHY. During testing we noticed that very occasionally (1% of the time) the first
-  packet sent after initialisation may be dropped for certain link partners. Subsequent packets are always OK.
-  This is consistent with a similar bug seen on the `TI forum <https://e2e.ti.com/support/interface-  group/interface/f/interface-forum/956808/dp83822i-after-link-up-first-packet-is-not-being-transmitted>`_.
-  For most applications this is not an issue however for test cases it may be worth noting. Sending an initial dummy Tx packet works around this issue.
+* Support for SMI (used in the Ethernet PHY drivers) requires the lib_ethernet dependency, which is not included in
+  this repository to avoid introducing dependencies into non-Ethernet applications. Any Ethernet application 
+  targeting either XK-EVK-XU216 or XK-ETH-316-DUAL boards must include lib_ethernet explicitly.
 
 ****************
 Development repo

--- a/doc/rst/lib_board_support.rst
+++ b/doc/rst/lib_board_support.rst
@@ -28,12 +28,8 @@ The following boards are supported in this repo with interfaces provided in the 
 +-----------------------+---------------------+
 |XK_EVK_XE216           |       XC            |
 +-----------------------+---------------------+
-|XK_ETH_XU316_DUAL_100M |       XC            |
+|XK_ETH_316_DUAL        |       XC            |
 +-----------------------+---------------------+
-
-.. note::
-    The XK_ETH_XU316_DUAL_100M board is not currently generally available and does not have official
-    documentation. Contact `XMOS` for further information.
 
 The following sections provide specific details of the features for each of the boards supported by this library.
 
@@ -155,10 +151,10 @@ XK_EVK_XU216 API
 
 |newpage|
 
-XK_ETH_XU316_DUAL_100M API
+XK_ETH_316_DUAL API
 ==========================
 
-.. doxygengroup:: xk_eth_xu316_dual_100m
+.. doxygengroup:: xk_eth_316_dual
    :content-only:
 
 |newpage|

--- a/lib_board_support/api/boards/boards_utils.h
+++ b/lib_board_support/api/boards/boards_utils.h
@@ -32,11 +32,14 @@
 /** Define representing XK-EVK-XU216 board */
 #define XK_EVK_XE216                4
 
+/** Define representing XK-ETH-316-DUAL board */
+#define XK_ETH_316_DUAL             5
+
 /** Define representing XK-ETH-XU316-DUAL-100M board */
-#define XK_ETH_XU316_DUAL_100M      5
+#define XK_ETH_XU316_DUAL_100M      6
 
 /** Total number of boards supported by the library */
-#define BOARD_SUPPORT_N_BOARDS      6  // max board + 1
+#define BOARD_SUPPORT_N_BOARDS      7  // max board + 1
 
 /** Define that should be set to the current board type in use
   *

--- a/lib_board_support/api/boards/xk_eth_316_dual/board.h
+++ b/lib_board_support/api/boards/xk_eth_316_dual/board.h
@@ -1,0 +1,79 @@
+// Copyright 2025 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+
+#ifndef __XK_ETH_316_DUAL_BOARD_H__
+#define __XK_ETH_316_DUAL_BOARD_H__
+
+#include <boards_utils.h>
+#if (BOARD_SUPPORT_BOARD == XK_ETH_316_DUAL) || defined(__DOXYGEN__)
+#include <xccompat.h>
+#include "smi.h"
+
+#ifndef NULLABLE_CLIENT_INTERFACE
+#ifdef __XC__
+#define NULLABLE_CLIENT_INTERFACE(tag, name) client interface tag ?name
+#else
+#define NULLABLE_CLIENT_INTERFACE(type, name) unsigned name
+#endif
+#endif // NULLABLE_CLIENT_INTERFACE
+
+/**
+ * \addtogroup xk_eth_316_dual
+ *
+ * API for the XK-ETH-316-DUAL board.
+ * @{
+ */
+
+ /** Index value used with get_port_timings() to refer to which PHY is in operation.
+  *
+  * The timings change according to which PHY is active in the hardware configuration
+  * of the dual PHY dev-kit.
+  */
+typedef enum {
+    NULL_PHY_TIMINGS,
+    PHY0_PORT_TIMINGS,
+    PHY1_PORT_TIMINGS,
+} port_timing_index_t;
+
+/** Task that connects to the SMI master and MAC to configure the
+ * DP83825I PHYs and monitor the link status. Note this task is combinable
+ * (typically with SMI) and therefore does not need to take a whole thread.
+ * 
+ * \note It is not necessary to use both PHYs. If only one PHY is used, TBC. TODO fix this.
+ *
+ *  \param i_smi        Client register read/write interface
+ *  \param i_eth_phy_0  Client MAC configuration interface for PHY_0. Set to NULL if unused.
+ *  \param i_eth_phy_1  Client MAC configuration interface for PHY_1. Set to NULL if unused.
+ */
+[[combinable]]
+void dual_ethernet_phy_driver(CLIENT_INTERFACE(smi_if, i_smi),
+                              NULLABLE_CLIENT_INTERFACE(ethernet_cfg_if, i_eth_phy_0),
+                              NULLABLE_CLIENT_INTERFACE(ethernet_cfg_if, i_eth_phy_1));
+
+/** Sends hard reset to both PHYs. Both PHYs will be ready for SMI
+ * communication once this function has returned.
+ * This function must be called from Tile[1].
+ * 
+ * \warning This function will reset both PHYs and the audio codec. To reset
+ * one of these devices after start-up, use the smi_phy_reset() function to
+ * set the reset bit in PHY Basic Control register.
+ *
+ */
+void reset_eth_phys(void);
+
+/** Returns a timing struct tuned to the XK-ETH-316-DUAL hardware.
+ * This struct should be passed to the call to rmii_ethernet_rt_mac() and will
+ * ensure setup and hold times are maximised at the pin level of the PHY connection.
+ * rmii_port_timing_t is defined in lib_ethernet.
+ * 
+ *  \param phy_idx      The index of the PHY to get timing data about.
+ *  \returns            The timing struct to be passed to the PHY.
+ */
+rmii_port_timing_t get_port_timings(port_timing_index_t phy_idx);
+
+
+/**@}*/ // END: addtogroup xk_eth_316_dual
+
+#endif // (BOARD_SUPPORT_BOARD == XK_ETH_316_DUAL) || defined(__DOXYGEN__)
+
+#endif // __XK_ETH_316_DUAL_BOARD_H__

--- a/lib_board_support/lib_build_info.cmake
+++ b/lib_board_support/lib_build_info.cmake
@@ -1,6 +1,6 @@
 set(LIB_NAME               lib_board_support)
 
-set(LIB_VERSION            1.3.0)
+set(LIB_VERSION            1.4.0)
 
 set(LIB_INCLUDES           api/boards api/drivers)
 
@@ -8,8 +8,8 @@ set(LIB_COMPILER_FLAGS     -Os -g)
 
 set(LIB_OPTIONAL_HEADERS   board_support_conf.h)
 
-set(LIB_DEPENDENT_MODULES  "lib_i2c(6.4.0)"
-                           "lib_sw_pll(2.4.0)"
-                           "lib_xassert(4.3.2)")
+set(LIB_DEPENDENT_MODULES  "lib_xassert(4.3.2)"
+                           "lib_i2c(6.4.0)"
+                           "lib_sw_pll(2.4.0)")
 
 XMOS_REGISTER_MODULE()

--- a/lib_board_support/module_build_info
+++ b/lib_board_support/module_build_info
@@ -1,4 +1,4 @@
-VERSION = 1.3.0
+VERSION = 1.4.0
 
 DEPENDENT_MODULES = lib_i2c(>=6.4.0)
                     lib_sw_pll(>=2.4.0)

--- a/lib_board_support/src/boards/xk_eth_316_dual/xk_eth_316_dual.xc
+++ b/lib_board_support/src/boards/xk_eth_316_dual/xk_eth_316_dual.xc
@@ -24,6 +24,9 @@
 #define PHY_RST_DURATION_US       100
 #define POST_RST_PHY_DELAY_MS     55
 
+// Time pending macro, difference must be less than (UINT32_MAX / 2) or ~20 seconds.
+#define TIME_PENDING(target, now) ((int32_t)((uint32_t)(target) - (uint32_t)(now)) > 0)
+
 // Bit 3 of this port is connected to the PHY resets. Other bits not pinned out.
 on tile[1] : out port p_phy_rst = PERIPH_RST;
 
@@ -47,7 +50,8 @@ void reset_eth_phys() {
 }
 
 static int check_phy_responds(client interface smi_if i_smi, unsigned phy_address, uint32_t timeout_s) {
-  int result = 0;
+
+  assert((timeout_s <= 20) && msg("Timeout value too large, should be less than or equal to 20s"));
 
   timer tmr;
   uint32_t timeout;
@@ -58,8 +62,8 @@ static int check_phy_responds(client interface smi_if i_smi, unsigned phy_addres
   fail_time = now + (timeout_s * XS1_TIMER_HZ);
   timeout = now + XS1_TIMER_HZ / 2;
 
-  result = smi_phy_is_powered_down(i_smi, phy_address);
-  while ((result == 1) && (fail_time > now))
+  int result = smi_phy_is_powered_down(i_smi, phy_address);
+  while ((result == 1) && TIME_PENDING(fail_time, now))
   {
     select {
       case tmr when timerafter(timeout) :> unsigned current:

--- a/lib_board_support/src/boards/xk_eth_316_dual/xk_eth_316_dual.xc
+++ b/lib_board_support/src/boards/xk_eth_316_dual/xk_eth_316_dual.xc
@@ -1,0 +1,209 @@
+// Copyright 2025 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+
+#include "boards_utils.h"
+#include "xk_eth_316_dual/board.h"
+
+#if BOARD_SUPPORT_BOARD == XK_ETH_316_DUAL
+#include <platform.h>
+#include <xs1.h>
+
+#define DEBUG_UNIT xk_eth_316_dual
+#include "debug_print.h"
+#include "xassert.h"
+
+#define MMD_GENERAL_RANGE         0x001F
+
+// IO Config Register address
+#define IO_CONFIG_REG             0x0302
+
+// IO configuration register bits
+#define IO_CONFIG_CRS_RX_DV_BIT   8
+#define IO_CONFIG_25_OHMS_BIT     14
+
+#define PHY_RST_DURATION_US       100
+#define POST_RST_PHY_DELAY_MS     55
+
+// Bit 3 of this port is connected to the PHY resets. Other bits not pinned out.
+on tile[1] : out port p_phy_rst = PERIPH_RST;
+
+#define ETH_PHY_0_ADDR 0x00
+#define ETH_PHY_1_ADDR 0x02
+static const uint8_t phy_addresses[2] = {ETH_PHY_0_ADDR, ETH_PHY_1_ADDR};
+
+static void set_mmd_reg_bitmask(client interface smi_if i_smi, unsigned phy_address, 
+                                unsigned reg_addr, unsigned mask) {
+
+  uint16_t reg_val = smi_mmd_read(i_smi, phy_address, MMD_GENERAL_RANGE, reg_addr);
+  reg_val |= mask;
+  smi_mmd_write(i_smi, phy_address, MMD_GENERAL_RANGE, reg_addr, reg_val);
+}
+
+void reset_eth_phys() {
+  p_phy_rst <: 0x08;                          // Set bit 3 high to reset the PHY and codec
+  delay_microseconds(PHY_RST_DURATION_US);    // dp83825i datasheet says 25us min
+  p_phy_rst <: 0x00;                          // Set bit 3 low
+  delay_milliseconds(POST_RST_PHY_DELAY_MS);  // dp83825i datasheet says 50ms max to be ready for SMI communication
+}
+
+static int check_phy_responds(client interface smi_if i_smi, unsigned phy_address, uint32_t timeout_s) {
+  int result = 0;
+
+  timer tmr;
+  uint32_t timeout;
+  uint32_t fail_time;
+  uint32_t now;
+
+  tmr :> now;
+  fail_time = now + (timeout_s * XS1_TIMER_HZ);
+  timeout = now + XS1_TIMER_HZ / 2;
+
+  result = smi_phy_is_powered_down(i_smi, phy_address);
+  while ((result == 1) && (fail_time > now))
+  {
+    select {
+      case tmr when timerafter(timeout) :> unsigned current:
+        // Power up the PHY
+        now = current;
+        result = smi_phy_is_powered_down(i_smi, phy_address);
+        timeout += XS1_TIMER_HZ / 2;
+        break;
+    }
+  }
+  return result;
+}
+
+rmii_port_timing_t get_port_timings(port_timing_index_t phy_idx) {
+  rmii_port_timing_t port_timing = {0, 0, 0, 0, 0};
+  
+  if (phy_idx == PHY0_PORT_TIMINGS) {
+    port_timing.clk_delay_tx_rising = 4;
+    port_timing.clk_delay_tx_falling = 4;
+    port_timing.clk_delay_rx_rising = 0;
+    port_timing.clk_delay_rx_falling = 0;
+    port_timing.pad_delay_rx = 0;
+
+  // TODO - test and update timings for this board - PHY1
+  } else if (phy_idx == PHY1_PORT_TIMINGS) {
+    port_timing.clk_delay_tx_rising = 0;
+    port_timing.clk_delay_tx_falling = 0;
+    port_timing.clk_delay_rx_rising = 0;
+    port_timing.clk_delay_rx_falling = 0;
+    port_timing.pad_delay_rx = 0;
+
+  } else {
+    fail("Invalid PHY idx\n");
+  }
+
+  return port_timing;
+}
+
+[[combinable]]
+void dual_ethernet_phy_driver(client interface smi_if i_smi,
+                              client interface ethernet_cfg_if ?i_eth_phy0,
+                              client interface ethernet_cfg_if ?i_eth_phy1) {
+  // Determine config. We always configure PHY0 because it is clock master.
+  // We may use any combination of at least one PHY.
+  // PHY0 is index 0 and PHY1 is index 1
+  int use_phy0 = !isnull(i_eth_phy0);
+  int use_phy1 = !isnull(i_eth_phy1);
+  int num_phys_to_configure = 0;
+  int num_phys_to_poll = 0;
+  int idx_of_first_phy_to_poll = 0;
+
+  if (use_phy0 && use_phy1) {
+    num_phys_to_configure = 2;
+    num_phys_to_poll = 2;
+    idx_of_first_phy_to_poll = 0;
+  } else if (use_phy0 && !use_phy1) {
+    num_phys_to_configure = 1;
+    num_phys_to_poll = 1;
+    idx_of_first_phy_to_poll = 0;
+  } else if (!use_phy0 && use_phy1) {
+    num_phys_to_configure = 2;
+    num_phys_to_poll = 1;
+    idx_of_first_phy_to_poll = 1;
+  } else {
+    fail("Must specify at least one ethernet_cfg_if configuration interface");
+  }
+
+  reset_eth_phys();
+
+  ethernet_link_state_t link_state[2] = {ETHERNET_LINK_DOWN, ETHERNET_LINK_DOWN};
+  ethernet_speed_t link_speed[2] = {LINK_100_MBPS_FULL_DUPLEX, LINK_100_MBPS_FULL_DUPLEX};
+  const int link_poll_period_ms = 1000;
+
+  // PHY_0 is the clock master so we always configure this one, even if only PHY_1 is used
+  // because PHY_1 is the clock slave and PHY_0 is the clock master
+
+  // Setup PHYs. Always configure PHY_0, optionally PHY_1
+  for (int phy_idx = 0; phy_idx < num_phys_to_configure; phy_idx++) {
+    uint8_t phy_address = phy_addresses[phy_idx];
+
+    int phy_state = check_phy_responds(i_smi, phy_address, 10);
+    assert(phy_state == 0 && msg("PHY failed to respond\n"));
+
+    debug_printf("Starting PHY %d\n", phy_idx);
+
+    smi_configure(i_smi, phy_address, link_speed[phy_idx], SMI_ENABLE_AUTONEG);
+
+    // Ensure RXDV is set.
+    // Also set pins to higher drive strength "impedance control".
+    set_mmd_reg_bitmask(i_smi, phy_address, IO_CONFIG_REG, (1 << IO_CONFIG_25_OHMS_BIT) | (1 << IO_CONFIG_CRS_RX_DV_BIT));
+
+    // Specific setup for PHY_0
+    if (phy_idx == 0) {
+      // None
+    }
+
+    // Specific setup for PHY_1 (if used)
+    if (phy_idx == 1) {
+      // None
+    }
+  }
+
+  // Timer for polling
+  timer tmr;
+  uint32_t t;
+  tmr :> t;
+
+  // Poll link state and update MAC if changed
+  while (1) {
+    select {
+      case tmr when timerafter(t) :> t:
+        for (int phy_idx = idx_of_first_phy_to_poll; phy_idx < (idx_of_first_phy_to_poll + num_phys_to_poll); phy_idx++) {
+          uint8_t phy_address = phy_addresses[phy_idx];
+          ethernet_link_state_t new_state = smi_get_link_state(i_smi, phy_address);
+
+          if (new_state != link_state[phy_idx]) {
+            link_state[phy_idx] = new_state;
+            if (new_state == ETHERNET_LINK_UP) {
+              link_speed[phy_idx] = smi_get_link_speed(i_smi, phy_address);
+            }
+            if (phy_idx == 0) {
+              i_eth_phy0.set_link_state(0, new_state, link_speed[phy_idx]);
+            } else {
+              i_eth_phy1.set_link_state(0, new_state, link_speed[phy_idx]);
+            }
+          }
+        }
+        t += link_poll_period_ms * XS1_TIMER_KHZ;
+        break;
+#if ENABLE_MAC_START_NOTIFICATION
+      case use_phy0 => i_eth_phy0.mac_started():
+        // Mac has just started, or restarted
+        i_eth_phy0.ack_mac_start();
+        i_eth_phy0.set_link_state(0, link_state[0], link_speed[0]);
+        break;
+
+      case use_phy1 => i_eth_phy1.mac_started():
+        // Mac has just started, or restarted
+        i_eth_phy1.ack_mac_start();
+        i_eth_phy1.set_link_state(0, link_state[1], link_speed[1]);
+        break;
+#endif
+    }
+  }
+}
+
+#endif  // BOARD_SUPPORT_BOARD == XK_ETH_316_DUAL

--- a/lib_board_support/src/boards/xk_eth_xu316_dual_100m/xk_eth_xu316_dual_100m.xc
+++ b/lib_board_support/src/boards/xk_eth_xu316_dual_100m/xk_eth_xu316_dual_100m.xc
@@ -4,9 +4,12 @@
 #include <xk_eth_xu316_dual_100m/board.h>
 #include <boards_utils.h>
 #if BOARD_SUPPORT_BOARD == XK_ETH_XU316_DUAL_100M
+
 #include <xs1.h>
 #include <platform.h>
-#include <stdio.h>
+
+#define DEBUG_UNIT xk_eth_xu316_dual_100
+#include "debug_print.h"
 #include "xassert.h"
 
 
@@ -15,26 +18,25 @@ on tile[1]: out port p_phy_rst_n = PHY_RST_N;
 on tile[1]: port p_pwrdn_int = PWRDN_INT;
 on tile[1]: out port p_leds = LED_GRN_RED;
 
+#define MMD_GENERAL_RANGE                   0x001F
+
+// Register addresses
+#define IO_CONFIG1_REG                      0x302
+#define LEDCFG_REG                          0x460
+
+// IO configuration register bits (0x302)
+#define IO_CFG1_IMPEDANCE_FAST_MODE_BIT     14
+#define IO_CFG1_CRS_RX_DV_BIT               8
+
 #define ETH_PHY_0_ADDR 0x05
 #define ETH_PHY_1_ADDR 0x07
-const int phy_addresses[2] = {ETH_PHY_0_ADDR, ETH_PHY_1_ADDR};
+static const uint8_t phy_addresses[2] = {ETH_PHY_0_ADDR, ETH_PHY_1_ADDR};
 
 // These drive low for on so set all other bits to high (we use drive_low mode)
 #define LED_OFF 0xffffffff
 #define LED_RED 0xfffffffd
 #define LED_GRN 0xfffffffe
 #define LED_YEL 0xfffffffc
-
-static void set_smi_reg_bit(CLIENT_INTERFACE(smi_if, i_smi), unsigned phy_address, unsigned reg_addr, unsigned bit, unsigned val)
-{
-    uint16_t reg_val = i_smi.read_reg(phy_address, reg_addr);
-    if(val){
-        reg_val |= (0x1 << bit);
-    } else {
-         reg_val &= ~(0x1 << bit);
-    }
-    i_smi.write_reg(phy_address, reg_addr, reg_val);
-}
 
 void reset_eth_phys()
 {
@@ -50,13 +52,13 @@ rmii_port_timing_t get_port_timings(port_timing_index_t phy_idx){
         port_timing.clk_delay_tx_rising = 1;
         port_timing.clk_delay_tx_falling = 1;
         port_timing.clk_delay_rx_rising = 0;
-        port_timing.clk_delay_tx_rising = 0;
+        port_timing.clk_delay_rx_falling = 0;
         port_timing.pad_delay_rx = 1;
     } else if((phy_idx == DUAL_PHY_MOUNTED_PHY1) || (phy_idx == SINGLE_PHY_MOUNTED_PHY0)) {
         port_timing.clk_delay_tx_rising = 0;
         port_timing.clk_delay_tx_falling = 0;
         port_timing.clk_delay_rx_rising = 0;
-        port_timing.clk_delay_tx_rising = 0;
+        port_timing.clk_delay_rx_falling = 0;
         port_timing.pad_delay_rx = 4;
     } else {
         fail("Invalid PHY idx\n");
@@ -111,15 +113,15 @@ void dual_dp83826e_phy_driver(CLIENT_INTERFACE(smi_if, i_smi),
     // PHY_0 is the clock master so we always configure this one, even if only PHY_1 is used
     // because PHY_1 is the clock slave and PHY_0 is the clock master
 
+    debug_printf("Starting PHY configuration\n");
+
     // Setup PHYs. Always configure PHY_0, optionally PHY_1
     for(int phy_idx = 0; phy_idx < num_phys_to_configure; phy_idx++){
-        int phy_address = phy_addresses[phy_idx];
+        uint8_t phy_address = phy_addresses[phy_idx];
 
         while(smi_phy_is_powered_down(i_smi, phy_address));
 
-        // Ensure we are set into RXDV rather than CS mode
-        set_smi_reg_bit(i_smi, phy_address, IO_CONFIG_1_REG, IO_CFG_CRS_RX_DV_BIT, 1);
-
+        debug_printf("Started PHY %d\n", phy_idx);
 
         // Set LED config to light the SPEED100M LED correctly. LEDCFG register (0x0460). LED2. Want to set bits 11-8 to 0x5.
         // Datasheet says LED control is on bits 11-8 but I think it's really bits 4-7.
@@ -127,11 +129,11 @@ void dual_dp83826e_phy_driver(CLIENT_INTERFACE(smi_if, i_smi),
         // we should do a read modify write of bits 4-7.
         // "Here this is a mistake in the datasheet, but please test which led has what registers, to my knowledge the settings described will configure the Leds mentioned."
         // "Led LED grouping is swapped so LED1 is 3-0 LED2 is 7-4 and LED3 is 11-8 the description status the same. Please confirm with your tests"
-        smi_mmd_write(i_smi, phy_address, 0x001F, 0x0460, 0x0555);
+        smi_mmd_write(i_smi, phy_address, MMD_GENERAL_RANGE, LEDCFG_REG, 0x0555);
 
         // Set pins to higher drive strength "impedance control". This is needed especially for clock signal. This results in a wider eye by some 2ns also.
         // Note we also ensure RXDV is set too
-        smi_mmd_write(i_smi, phy_address, 0x001F, 0x0302, 0xC100);
+        smi_mmd_write(i_smi, phy_address, MMD_GENERAL_RANGE, IO_CONFIG1_REG, (1 << IO_CFG1_IMPEDANCE_FAST_MODE_BIT) | (1 << IO_CFG1_CRS_RX_DV_BIT));
 
         // Specific setup for PHY_0
         if(phy_idx == 0){
@@ -158,7 +160,7 @@ void dual_dp83826e_phy_driver(CLIENT_INTERFACE(smi_if, i_smi),
         select {
             case tmr when timerafter(t) :> t:
                 for(int phy_idx = idx_of_first_phy_to_poll; phy_idx < idx_of_first_phy_to_poll + num_phys_to_poll; phy_idx++){
-                    int phy_address = phy_addresses[phy_idx];
+                    uint8_t phy_address = phy_addresses[phy_idx];
                     ethernet_link_state_t new_state = smi_get_link_state(i_smi, phy_address);
 
                     if (new_state != link_state[phy_idx]) {

--- a/lib_board_support/src/boards/xk_evk_xe216/xk_evk_xe216_board.xc
+++ b/lib_board_support/src/boards/xk_evk_xe216/xk_evk_xe216_board.xc
@@ -7,6 +7,7 @@
 #include <xs1.h>
 #include <platform.h>
 
+#define DEBUG_UNIT xk_evk_xe216
 #include <debug_print.h>
 
 // The following supports PHY chips on different versions of XK-EVK-XE216

--- a/settings.yml
+++ b/settings.yml
@@ -3,7 +3,7 @@
 lib_name: lib_board_support
 project: '{{lib_name}}'
 title: '{{lib_name}}: XMOS board support'
-version: 1.3.0
+version: 1.4.0
 
 documentation:
   exclude_patterns_path: doc/exclude_patterns.inc

--- a/xn_files/xk-eth-316-dual.xn
+++ b/xn_files/xk-eth-316-dual.xn
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Network xmlns="http://www.xmos.com"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://www.xmos.com http://www.xmos.com">
+  <Type>Board</Type>
+  <Name>xcore.ai Daisy Chain Ethernet</Name>
+
+  <Declarations>
+    <Declaration>tileref tile[2]</Declaration>
+  </Declarations>
+
+  <Packages>
+    <Package id="0" Type="XS3-UnA-1024-QF60B">
+      <Nodes>
+        <Node Id="0" InPackageId="0" Type="XS3-L16A-1024" Oscillator="25MHz" SystemFrequency="600MHz" ReferenceFrequency="100MHz">
+          <Boot>
+            <Source Location="bootFlash"/>
+          </Boot>
+          <Tile Number="0" Reference="tile[0]">
+            <Port Location="XS1_PORT_1B"  Name="PORT_SQI_CS"/>
+            <Port Location="XS1_PORT_1C"  Name="PORT_SQI_SCLK"/>
+            <Port Location="XS1_PORT_4B"  Name="PORT_SQI_SIO"/>
+            
+            <!-- PHY 0 Uses upper 2 bits of 4b ports for Data -->
+            <Port Location="XS1_PORT_1A" Name="PHY_0_TX_EN"/>
+            <Port Location="XS1_PORT_4F" Name="PHY_0_TXD_4BIT"/>
+            <Port Location="XS1_PORT_1D" Name="PHY_0_RXDV"/>
+            <Port Location="XS1_PORT_4E" Name="PHY_0_RXD_4BIT"/>
+            
+            <!-- PHY 1 Uses 1b ports for Rx Data and 8b port for Tx Data -->
+            <Port Location="XS1_PORT_1L" Name="PHY_1_TX_EN"/>
+            <Port Location="XS1_PORT_8D" Name="PHY_1_TXD_8BIT"/>
+            <Port Location="XS1_PORT_1M" Name="PHY_1_RXDV"/>
+            <Port Location="XS1_PORT_1N" Name="PHY_1_RXD_0"/>
+            <Port Location="XS1_PORT_1O" Name="PHY_1_RXD_1"/>
+            
+            <Port Location="XS1_PORT_1P" Name="PHY_CLK_50M"/>
+          </Tile>
+          <Tile Number="1" Reference="tile[1]">
+            <!-- Shared config pins for both PHYs -->
+            <Port Location="XS1_PORT_1F"  Name="MDC"/>
+            <Port Location="XS1_PORT_1G"  Name="MDIO"/>
+            
+            <!-- PHY control ines -->
+            <Port Location="XS1_PORT_4A"  Name="PERIPH_RST"/> <!-- PERIPH_RST on P4A3 -->
+            
+          </Tile>
+        </Node>
+      </Nodes>
+    </Package>
+  </Packages>
+
+  <!-- XTAG4 -->
+  <Nodes>
+    <Node Id="1" Type="device:" RoutingId="0x8000">
+      <Service Id="0" Proto="xscope_host_data(chanend c);">
+        <Chanend Identifier="c" end="3"/>
+      </Service>
+    </Node>
+  </Nodes>
+
+  <!-- XSCOPE LINK -->
+  <Links>
+    <Link Encoding="2wire" Delays="5clk" Flags="XSCOPE">
+      <LinkEndpoint NodeId="0" Link="XL0"/>
+      <LinkEndpoint NodeId="1" Chanend="1"/>
+    </Link>
+  </Links>
+
+  <ExternalDevices>
+    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" Type="W25Q16JV" PageSize="256" SectorSize="4096" NumPages="8192">
+      <Attribute Name="PORT_SQI_CS"   Value="PORT_SQI_CS"/>
+      <Attribute Name="PORT_SQI_SCLK" Value="PORT_SQI_SCLK"/>
+      <Attribute Name="PORT_SQI_SIO"  Value="PORT_SQI_SIO"/>
+    </Device>
+  </ExternalDevices>
+
+  <JTAGChain>
+    <JTAGDevice NodeId="0"/>
+  </JTAGChain>
+
+</Network>


### PR DESCRIPTION
Adding support for new dual ethernet dev-kit. BUT, only first PHY for now. For reference these changes are built in lib_ethernet PR, https://github.com/xmos/lib_ethernet/pull/182

Documentation update to follow this PR.

Please note, to complete port will need the following tasks to be completed on lib_ethernet,
* https://github.com/xmos/lib_ethernet/pull/85
* https://github.com/xmos/lib_ethernet/pull/91

Plus, updates to dual ethernet test board driver to fix issue of trying to access vendor specific register (0x302) without using MMD function. Added defines for magic numbers.
Also, added debug units to ethernet boards, for selective debug output.